### PR TITLE
mbed TLS client support, try 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ This library is the base for [ESPAsyncWebServer](https://github.com/me-no-dev/ES
 
 ## AsyncClient and AsyncServer
 The base classes on which everything else is built. They expose all possible scenarios, but are really raw and require more skills to use.
+
+## TLS support
+Support for TLS is added using mbed TLS, for now only the client part is supported. You can enable this by adding the flag ASYNC_TCP_SSL_ENABLED to your build flags (-DASYNC_TCP_SSL_ENABLED). If you'd like to set a root certificate you can use the setRootCa function on AsyncClient. Feel free to add support for the server side as well :-)

--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ The base classes on which everything else is built. They expose all possible sce
 
 ## TLS support
 Support for TLS is added using mbed TLS, for now only the client part is supported. You can enable this by adding the flag ASYNC_TCP_SSL_ENABLED to your build flags (-DASYNC_TCP_SSL_ENABLED). If you'd like to set a root certificate you can use the setRootCa function on AsyncClient. Feel free to add support for the server side as well :-)
+
+In addition to the regular certificate based cipher suites there is also support for Pre-Shared Key
+cipher suites. Use `setPsk` to define the PSK identifier and PSK itself. The PSK needs to be
+provided in the form of a hex string (and easy way to generate a PSK is to use md5sum).

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -716,8 +716,6 @@ int8_t AsyncClient::_poll(tcp_pcb* pcb){
 
 void AsyncClient::_dns_found(ip_addr_t *ipaddr){
     _in_lwip_thread = true;
-    Serial.print("ip: ");
-    Serial.println(ipaddr_ntoa(ipaddr));
 
     if(ipaddr){
 #if ASYNC_TCP_SSL_ENABLED

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -1099,7 +1099,6 @@ int8_t AsyncClient::_s_connected(void * arg, void * pcb, int8_t err){
 }
 
 void AsyncClient::_s_data(void *arg, struct tcp_pcb *tcp, uint8_t * data, size_t len){
-  log_i("_s_data");
   AsyncClient *c = reinterpret_cast<AsyncClient*>(arg);
   if(c->_recv_cb)
     c->_recv_cb(c->_recv_cb_arg, c, data, len);
@@ -1107,7 +1106,6 @@ void AsyncClient::_s_data(void *arg, struct tcp_pcb *tcp, uint8_t * data, size_t
 
 void AsyncClient::_s_handshake(void *arg, struct tcp_pcb *tcp, struct tcp_ssl_pcb* ssl){
   AsyncClient *c = reinterpret_cast<AsyncClient*>(arg);
-  log_i("_s_handshake: done!");
   c->_handshake_done = true;
   if(c->_connect_cb)
     c->_connect_cb(c->_connect_cb_arg, c);

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -626,11 +626,12 @@ int8_t AsyncClient::_recv(tcp_pcb* pcb, pbuf* pb, int8_t err) {
             // log_i("_recv: %d\n", pb->tot_len);
             int read_bytes = tcp_ssl_read(pcb, pb);
             if(read_bytes < 0){
-            if (read_bytes != MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
-                log_e("_recv err: %d\n", read_bytes);
-                _close();
-            }
-            //return read_bytes;
+                if (read_bytes != MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+                    log_e("_recv err: %d\n", read_bytes);
+                    _close();
+                }
+                
+                //return read_bytes;
             }
             return ERR_OK;
         }
@@ -684,13 +685,6 @@ int8_t AsyncClient::_poll(tcp_pcb* pcb){
         _close();
         return ERR_OK;
     }
-    // if(!_handshake_done) {
-    //     _in_lwip_thread = true;
-    //     tcp_ssl_handshake_step(pcb);
-    //     _in_lwip_thread = false;
-
-    //     return ERR_OK;
-    // }
     // Everything is fine
     if(_poll_cb)
         _poll_cb(_poll_cb_arg, this);
@@ -812,7 +806,7 @@ size_t AsyncClient::add(const char* data, size_t size, uint8_t apiflags) {
             //_tx_unacked_len += sent;
             return sent;
         }
-        log_i("add: tcp_ssl_write: %d", sent);
+        //log_i("add: tcp_ssl_write: %d", sent);
         _close();
         return 0;
     }

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -256,7 +256,7 @@ static void _tcp_error(void * arg, int8_t err) {
 #include "lwip/priv/tcpip_priv.h"
 
 typedef struct {
-    struct tcpip_api_call call;
+    struct tcpip_api_call_data call;
     tcp_pcb * pcb;
     int8_t err;
     union {
@@ -279,7 +279,7 @@ typedef struct {
     };
 } tcp_api_call_t;
 
-static err_t _tcp_output_api(struct tcpip_api_call *api_call_msg){
+static err_t _tcp_output_api(struct tcpip_api_call_data *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = tcp_output(msg->pcb);
     return msg->err;
@@ -288,11 +288,11 @@ static err_t _tcp_output_api(struct tcpip_api_call *api_call_msg){
 static esp_err_t _tcp_output(tcp_pcb * pcb) {
     tcp_api_call_t msg;
     msg.pcb = pcb;
-    tcpip_api_call(_tcp_output_api, (struct tcpip_api_call*)&msg);
+    tcpip_api_call(_tcp_output_api, (struct tcpip_api_call_data*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_write_api(struct tcpip_api_call *api_call_msg){
+static err_t _tcp_write_api(struct tcpip_api_call_data *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = tcp_write(msg->pcb, msg->write.data, msg->write.size, msg->write.apiflags);
     return msg->err;
@@ -304,11 +304,11 @@ static esp_err_t _tcp_write(tcp_pcb * pcb, const char* data, size_t size, uint8_
     msg.write.data = data;
     msg.write.size = size;
     msg.write.apiflags = apiflags;
-    tcpip_api_call(_tcp_write_api, (struct tcpip_api_call*)&msg);
+    tcpip_api_call(_tcp_write_api, (struct tcpip_api_call_data*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_recved_api(struct tcpip_api_call *api_call_msg){
+static err_t _tcp_recved_api(struct tcpip_api_call_data *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = 0;
     tcp_recved(msg->pcb, msg->received);
@@ -319,11 +319,11 @@ static esp_err_t _tcp_recved(tcp_pcb * pcb, size_t len) {
     tcp_api_call_t msg;
     msg.pcb = pcb;
     msg.received = len;
-    tcpip_api_call(_tcp_recved_api, (struct tcpip_api_call*)&msg);
+    tcpip_api_call(_tcp_recved_api, (struct tcpip_api_call_data*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_connect_api(struct tcpip_api_call *api_call_msg){
+static err_t _tcp_connect_api(struct tcpip_api_call_data *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = tcp_connect(msg->pcb, msg->connect.addr, msg->connect.port, msg->connect.cb);
     return msg->err;
@@ -335,11 +335,11 @@ static esp_err_t _tcp_connect(tcp_pcb * pcb, ip_addr_t * addr, uint16_t port, tc
     msg.connect.addr = addr;
     msg.connect.port = port;
     msg.connect.cb = cb;
-    tcpip_api_call(_tcp_connect_api, (struct tcpip_api_call*)&msg);
+    tcpip_api_call(_tcp_connect_api, (struct tcpip_api_call_data*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_close_api(struct tcpip_api_call *api_call_msg){
+static err_t _tcp_close_api(struct tcpip_api_call_data *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = tcp_close(msg->pcb);
     return msg->err;
@@ -349,11 +349,11 @@ static esp_err_t _tcp_close(tcp_pcb * pcb) {
     tcp_api_call_t msg;
     msg.pcb = pcb;
     //ets_printf("close 0x%08x\n", (uint32_t)pcb);
-    tcpip_api_call(_tcp_close_api, (struct tcpip_api_call*)&msg);
+    tcpip_api_call(_tcp_close_api, (struct tcpip_api_call_data*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_abort_api(struct tcpip_api_call *api_call_msg){
+static err_t _tcp_abort_api(struct tcpip_api_call_data *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = 0;
     tcp_abort(msg->pcb);
@@ -364,11 +364,11 @@ static esp_err_t _tcp_abort(tcp_pcb * pcb) {
     tcp_api_call_t msg;
     msg.pcb = pcb;
     //ets_printf("abort 0x%08x\n", (uint32_t)pcb);
-    tcpip_api_call(_tcp_abort_api, (struct tcpip_api_call*)&msg);
+    tcpip_api_call(_tcp_abort_api, (struct tcpip_api_call_data*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_bind_api(struct tcpip_api_call *api_call_msg){
+static err_t _tcp_bind_api(struct tcpip_api_call_data *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = tcp_bind(msg->pcb, msg->bind.addr, msg->bind.port);
     return msg->err;
@@ -379,11 +379,11 @@ static esp_err_t _tcp_bind(tcp_pcb * pcb, ip_addr_t * addr, uint16_t port) {
     msg.pcb = pcb;
     msg.bind.addr = addr;
     msg.bind.port = port;
-    tcpip_api_call(_tcp_bind_api, (struct tcpip_api_call*)&msg);
+    tcpip_api_call(_tcp_bind_api, (struct tcpip_api_call_data*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_listen_api(struct tcpip_api_call *api_call_msg){
+static err_t _tcp_listen_api(struct tcpip_api_call_data *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = 0;
     msg->pcb = tcp_listen_with_backlog(msg->pcb, msg->backlog);
@@ -394,7 +394,7 @@ static tcp_pcb * _tcp_listen_with_backlog(tcp_pcb * pcb, uint8_t backlog) {
     tcp_api_call_t msg;
     msg.pcb = pcb;
     msg.backlog = backlog?backlog:0xFF;
-    tcpip_api_call(_tcp_listen_api, (struct tcpip_api_call*)&msg);
+    tcpip_api_call(_tcp_listen_api, (struct tcpip_api_call_data*)&msg);
     return msg.pcb;
 }
 #define _tcp_listen(p) _tcp_listen_with_backlog(p, 0xFF);
@@ -581,7 +581,7 @@ int8_t AsyncClient::_close(){
             err = abort();
         }
         _pcb = NULL;
-        _tcp_clear_events(this);
+        // _tcp_clear_events(this);
         if(_discard_cb)
             _discard_cb(_discard_cb_arg, this);
     }
@@ -628,12 +628,13 @@ int8_t AsyncClient::_sent(tcp_pcb* pcb, uint16_t len) {
 
 int8_t AsyncClient::_recv(tcp_pcb* pcb, pbuf* pb, int8_t err) {
     if(!_pcb || pcb != _pcb){
-        log_e("0x%08x != 0x%08x", (uint32_t)pcb, (uint32_t)_pcb);
-        if(pb){
-            pbuf_free(pb);
-        }
-        return ERR_OK;
-    }
+         log_e("0x%08x != 0x%08x", (uint32_t)pcb, (uint32_t)_pcb);
+         if(pb){
+             pbuf_free(pb);
+         }
+         return ERR_OK;
+     }
+
     _in_lwip_thread = false;
     if(pb == NULL){
         return _close();
@@ -714,7 +715,7 @@ int8_t AsyncClient::_poll(tcp_pcb* pcb){
     return ERR_OK;
 }
 
-void AsyncClient::_dns_found(ip_addr_t *ipaddr){
+void AsyncClient::_dns_found(struct ip_addr *ipaddr){
     _in_lwip_thread = true;
 
     if(ipaddr){
@@ -1072,12 +1073,20 @@ void AsyncClient::onPoll(AcConnectHandler cb, void* arg){
     _poll_cb_arg = arg;
 }
 
-void AsyncClient::_s_dns_found(const char * name, ip_addr_t * ipaddr, void * arg){
-    reinterpret_cast<AsyncClient*>(arg)->_dns_found(ipaddr);
+void AsyncClient::_s_dns_found(const char * name, struct ip_addr * ipaddr, void * arg){
+    if(arg){
+        reinterpret_cast<AsyncClient*>(arg)->_dns_found(ipaddr);
+    } else {
+        log_e("Bad Arg: 0x%08x", arg);
+    }
 }
 
 int8_t AsyncClient::_s_poll(void * arg, struct tcp_pcb * pcb) {
-    reinterpret_cast<AsyncClient*>(arg)->_poll(pcb);
+    if(arg && pcb){
+        reinterpret_cast<AsyncClient*>(arg)->_poll(pcb);
+    } else {
+        log_e("Bad Args: 0x%08x 0x%08x", arg, pcb);
+    }
     return ERR_OK;
 }
 
@@ -1086,7 +1095,7 @@ int8_t AsyncClient::_s_recv(void * arg, struct tcp_pcb * pcb, struct pbuf *pb, i
         reinterpret_cast<AsyncClient*>(arg)->_recv(pcb, pb, err);
     } else {
         if(pb){
-           pbuf_free(pb);
+        pbuf_free(pb);
         }
         log_e("Bad Args: 0x%08x 0x%08x", arg, pcb);
     }
@@ -1094,16 +1103,28 @@ int8_t AsyncClient::_s_recv(void * arg, struct tcp_pcb * pcb, struct pbuf *pb, i
 }
 
 int8_t AsyncClient::_s_sent(void * arg, struct tcp_pcb * pcb, uint16_t len) {
-    reinterpret_cast<AsyncClient*>(arg)->_sent(pcb, len);
+    if(arg && pcb){
+        reinterpret_cast<AsyncClient*>(arg)->_sent(pcb, len);
+    } else {
+        log_e("Bad Args: 0x%08x 0x%08x", arg, pcb);
+    }
     return ERR_OK;
 }
 
 void AsyncClient::_s_error(void * arg, int8_t err) {
-    reinterpret_cast<AsyncClient*>(arg)->_error(err);
+    if(arg){
+        reinterpret_cast<AsyncClient*>(arg)->_error(err);
+    } else {
+        log_e("Bad Arg: 0x%08x", arg);
+    }
 }
 
 int8_t AsyncClient::_s_connected(void * arg, void * pcb, int8_t err){
-    reinterpret_cast<AsyncClient*>(arg)->_connected(pcb, err);
+    if(arg && pcb){
+        reinterpret_cast<AsyncClient*>(arg)->_connected(pcb, err);
+    } else {
+        log_e("Bad Args: 0x%08x 0x%08x", arg, pcb);
+    }
     return ERR_OK;
 }
 

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -497,10 +497,12 @@ bool AsyncClient::connect(IPAddress ip, uint16_t port){
     return true;
 }
 
+#if ASYNC_TCP_SSL_ENABLED
 void AsyncClient::setRootCa(const char* rootca, const size_t len) {
     _root_ca = (char*)rootca;
     _root_ca_len = len;
 }
+#endif // ASYNC_TCP_SSL_ENABLED
 
 AsyncClient& AsyncClient::operator=(const AsyncClient& other){
     if (_pcb)

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -256,7 +256,7 @@ static void _tcp_error(void * arg, int8_t err) {
 #include "lwip/priv/tcpip_priv.h"
 
 typedef struct {
-    struct tcpip_api_call_data call;
+    struct tcpip_api_call call;
     tcp_pcb * pcb;
     int8_t err;
     union {
@@ -279,7 +279,7 @@ typedef struct {
     };
 } tcp_api_call_t;
 
-static err_t _tcp_output_api(struct tcpip_api_call_data *api_call_msg){
+static err_t _tcp_output_api(struct tcpip_api_call *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = tcp_output(msg->pcb);
     return msg->err;
@@ -288,11 +288,11 @@ static err_t _tcp_output_api(struct tcpip_api_call_data *api_call_msg){
 static esp_err_t _tcp_output(tcp_pcb * pcb) {
     tcp_api_call_t msg;
     msg.pcb = pcb;
-    tcpip_api_call(_tcp_output_api, (struct tcpip_api_call_data*)&msg);
+    tcpip_api_call(_tcp_output_api, (struct tcpip_api_call*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_write_api(struct tcpip_api_call_data *api_call_msg){
+static err_t _tcp_write_api(struct tcpip_api_call *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = tcp_write(msg->pcb, msg->write.data, msg->write.size, msg->write.apiflags);
     return msg->err;
@@ -304,11 +304,11 @@ static esp_err_t _tcp_write(tcp_pcb * pcb, const char* data, size_t size, uint8_
     msg.write.data = data;
     msg.write.size = size;
     msg.write.apiflags = apiflags;
-    tcpip_api_call(_tcp_write_api, (struct tcpip_api_call_data*)&msg);
+    tcpip_api_call(_tcp_write_api, (struct tcpip_api_call*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_recved_api(struct tcpip_api_call_data *api_call_msg){
+static err_t _tcp_recved_api(struct tcpip_api_call *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = 0;
     tcp_recved(msg->pcb, msg->received);
@@ -319,11 +319,11 @@ static esp_err_t _tcp_recved(tcp_pcb * pcb, size_t len) {
     tcp_api_call_t msg;
     msg.pcb = pcb;
     msg.received = len;
-    tcpip_api_call(_tcp_recved_api, (struct tcpip_api_call_data*)&msg);
+    tcpip_api_call(_tcp_recved_api, (struct tcpip_api_call*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_connect_api(struct tcpip_api_call_data *api_call_msg){
+static err_t _tcp_connect_api(struct tcpip_api_call *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = tcp_connect(msg->pcb, msg->connect.addr, msg->connect.port, msg->connect.cb);
     return msg->err;
@@ -335,11 +335,11 @@ static esp_err_t _tcp_connect(tcp_pcb * pcb, ip_addr_t * addr, uint16_t port, tc
     msg.connect.addr = addr;
     msg.connect.port = port;
     msg.connect.cb = cb;
-    tcpip_api_call(_tcp_connect_api, (struct tcpip_api_call_data*)&msg);
+    tcpip_api_call(_tcp_connect_api, (struct tcpip_api_call*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_close_api(struct tcpip_api_call_data *api_call_msg){
+static err_t _tcp_close_api(struct tcpip_api_call *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = tcp_close(msg->pcb);
     return msg->err;
@@ -349,11 +349,11 @@ static esp_err_t _tcp_close(tcp_pcb * pcb) {
     tcp_api_call_t msg;
     msg.pcb = pcb;
     //ets_printf("close 0x%08x\n", (uint32_t)pcb);
-    tcpip_api_call(_tcp_close_api, (struct tcpip_api_call_data*)&msg);
+    tcpip_api_call(_tcp_close_api, (struct tcpip_api_call*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_abort_api(struct tcpip_api_call_data *api_call_msg){
+static err_t _tcp_abort_api(struct tcpip_api_call *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = 0;
     tcp_abort(msg->pcb);
@@ -364,11 +364,11 @@ static esp_err_t _tcp_abort(tcp_pcb * pcb) {
     tcp_api_call_t msg;
     msg.pcb = pcb;
     //ets_printf("abort 0x%08x\n", (uint32_t)pcb);
-    tcpip_api_call(_tcp_abort_api, (struct tcpip_api_call_data*)&msg);
+    tcpip_api_call(_tcp_abort_api, (struct tcpip_api_call*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_bind_api(struct tcpip_api_call_data *api_call_msg){
+static err_t _tcp_bind_api(struct tcpip_api_call *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = tcp_bind(msg->pcb, msg->bind.addr, msg->bind.port);
     return msg->err;
@@ -379,11 +379,11 @@ static esp_err_t _tcp_bind(tcp_pcb * pcb, ip_addr_t * addr, uint16_t port) {
     msg.pcb = pcb;
     msg.bind.addr = addr;
     msg.bind.port = port;
-    tcpip_api_call(_tcp_bind_api, (struct tcpip_api_call_data*)&msg);
+    tcpip_api_call(_tcp_bind_api, (struct tcpip_api_call*)&msg);
     return msg.err;
 }
 
-static err_t _tcp_listen_api(struct tcpip_api_call_data *api_call_msg){
+static err_t _tcp_listen_api(struct tcpip_api_call *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = 0;
     msg->pcb = tcp_listen_with_backlog(msg->pcb, msg->backlog);
@@ -394,7 +394,7 @@ static tcp_pcb * _tcp_listen_with_backlog(tcp_pcb * pcb, uint8_t backlog) {
     tcp_api_call_t msg;
     msg.pcb = pcb;
     msg.backlog = backlog?backlog:0xFF;
-    tcpip_api_call(_tcp_listen_api, (struct tcpip_api_call_data*)&msg);
+    tcpip_api_call(_tcp_listen_api, (struct tcpip_api_call*)&msg);
     return msg.pcb;
 }
 #define _tcp_listen(p) _tcp_listen_with_backlog(p, 0xFF);
@@ -565,7 +565,7 @@ int8_t AsyncClient::_close(){
             err = abort();
         }
         _pcb = NULL;
-        // _tcp_clear_events(this);
+        _tcp_clear_events(this);
         if(_discard_cb)
             _discard_cb(_discard_cb_arg, this);
     }
@@ -608,13 +608,12 @@ int8_t AsyncClient::_sent(tcp_pcb* pcb, uint16_t len) {
 
 int8_t AsyncClient::_recv(tcp_pcb* pcb, pbuf* pb, int8_t err) {
     if(!_pcb || pcb != _pcb){
-         log_e("0x%08x != 0x%08x", (uint32_t)pcb, (uint32_t)_pcb);
-         if(pb){
-             pbuf_free(pb);
-         }
-         return ERR_OK;
-     }
-
+        log_e("0x%08x != 0x%08x", (uint32_t)pcb, (uint32_t)_pcb);
+        if(pb){
+            pbuf_free(pb);
+        }
+        return ERR_OK;
+    }
     _in_lwip_thread = false;
     if(pb == NULL){
         return _close();
@@ -691,7 +690,7 @@ int8_t AsyncClient::_poll(tcp_pcb* pcb){
     return ERR_OK;
 }
 
-void AsyncClient::_dns_found(struct ip_addr *ipaddr){
+void AsyncClient::_dns_found(ip_addr_t *ipaddr){
     _in_lwip_thread = true;
     Serial.print("ip: ");
     Serial.println(ipaddr_ntoa(ipaddr));
@@ -1037,20 +1036,12 @@ void AsyncClient::onPoll(AcConnectHandler cb, void* arg){
     _poll_cb_arg = arg;
 }
 
-void AsyncClient::_s_dns_found(const char * name, struct ip_addr * ipaddr, void * arg){
-    if(arg){
-        reinterpret_cast<AsyncClient*>(arg)->_dns_found(ipaddr);
-    } else {
-        log_e("Bad Arg: 0x%08x", arg);
-    }
+void AsyncClient::_s_dns_found(const char * name, ip_addr_t * ipaddr, void * arg){
+    reinterpret_cast<AsyncClient*>(arg)->_dns_found(ipaddr);
 }
 
 int8_t AsyncClient::_s_poll(void * arg, struct tcp_pcb * pcb) {
-    if(arg && pcb){
-        reinterpret_cast<AsyncClient*>(arg)->_poll(pcb);
-    } else {
-        log_e("Bad Args: 0x%08x 0x%08x", arg, pcb);
-    }
+    reinterpret_cast<AsyncClient*>(arg)->_poll(pcb);
     return ERR_OK;
 }
 
@@ -1059,7 +1050,7 @@ int8_t AsyncClient::_s_recv(void * arg, struct tcp_pcb * pcb, struct pbuf *pb, i
         reinterpret_cast<AsyncClient*>(arg)->_recv(pcb, pb, err);
     } else {
         if(pb){
-        pbuf_free(pb);
+           pbuf_free(pb);
         }
         log_e("Bad Args: 0x%08x 0x%08x", arg, pcb);
     }
@@ -1067,28 +1058,16 @@ int8_t AsyncClient::_s_recv(void * arg, struct tcp_pcb * pcb, struct pbuf *pb, i
 }
 
 int8_t AsyncClient::_s_sent(void * arg, struct tcp_pcb * pcb, uint16_t len) {
-    if(arg && pcb){
-        reinterpret_cast<AsyncClient*>(arg)->_sent(pcb, len);
-    } else {
-        log_e("Bad Args: 0x%08x 0x%08x", arg, pcb);
-    }
+    reinterpret_cast<AsyncClient*>(arg)->_sent(pcb, len);
     return ERR_OK;
 }
 
 void AsyncClient::_s_error(void * arg, int8_t err) {
-    if(arg){
-        reinterpret_cast<AsyncClient*>(arg)->_error(err);
-    } else {
-        log_e("Bad Arg: 0x%08x", arg);
-    }
+    reinterpret_cast<AsyncClient*>(arg)->_error(err);
 }
 
 int8_t AsyncClient::_s_connected(void * arg, void * pcb, int8_t err){
-    if(arg && pcb){
-        reinterpret_cast<AsyncClient*>(arg)->_connected(pcb, err);
-    } else {
-        log_e("Bad Args: 0x%08x 0x%08x", arg, pcb);
-    }
+    reinterpret_cast<AsyncClient*>(arg)->_connected(pcb, err);
     return ERR_OK;
 }
 

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -50,7 +50,6 @@ struct ip_addr;
 class AsyncClient {
   protected:
     tcp_pcb* _pcb;
-    // char* _hostname;
     std::string _hostname;
 
     AcConnectHandler _connect_cb;

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -45,7 +45,7 @@ typedef std::function<void(void*, AsyncClient*, struct pbuf *pb)> AcPacketHandle
 typedef std::function<void(void*, AsyncClient*, uint32_t time)> AcTimeoutHandler;
 
 struct tcp_pcb;
-struct ip_addr;
+struct _ip_addr;
 
 class AsyncClient {
   protected:
@@ -87,7 +87,7 @@ class AsyncClient {
     void _ssl_error(int8_t err);
     int8_t _poll(tcp_pcb* pcb);
     int8_t _sent(tcp_pcb* pcb, uint16_t len);
-    void _dns_found(struct ip_addr *ipaddr);
+    void _dns_found(struct _ip_addr *ipaddr);
     static void _s_data(void *arg, struct tcp_pcb *tcp, uint8_t * data, size_t len);
     static void _s_handshake(void *arg, struct tcp_pcb *tcp, struct tcp_ssl_pcb* ssl);
     static void _s_ssl_error(void *arg, struct tcp_pcb *tcp, int8_t err);
@@ -116,13 +116,13 @@ class AsyncClient {
 
     bool canSend();//ack is not pending
     size_t space();
-    size_t add(const char* data, size_t size, uint8_t apiflags=ASYNC_WRITE_FLAG_COPY);//add for sending
+    size_t add(const char* data, size_t size, uint8_t apiflags=0);//add for sending
     bool send();//send all data added with the method above
     size_t ack(size_t len); //ack data that you have not acked using the method below
     void ackLater(){ _ack_pcb = false; } //will not ack the current packet. Call from onData
 
     size_t write(const char* data);
-    size_t write(const char* data, size_t size, uint8_t apiflags=ASYNC_WRITE_FLAG_COPY); //only when canSend() == true
+    size_t write(const char* data, size_t size, uint8_t apiflags=0); //only when canSend() == true
 
     uint8_t state();
     bool connecting();
@@ -169,7 +169,7 @@ class AsyncClient {
     static void _s_error(void *arg, int8_t err);
     static int8_t _s_sent(void *arg, struct tcp_pcb *tpcb, uint16_t len);
     static int8_t _s_connected(void* arg, void* tpcb, int8_t err);
-    static void _s_dns_found(const char *name, struct ip_addr *ipaddr, void *arg);
+    static void _s_dns_found(const char *name, struct _ip_addr *ipaddr, void *arg);
 
     bool _in_lwip_thread;
 };

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -50,7 +50,8 @@ struct ip_addr;
 class AsyncClient {
   protected:
     tcp_pcb* _pcb;
-    // sslclient_context* _ssl_context;
+    // char* _hostname;
+    std::string _hostname;
 
     AcConnectHandler _connect_cb;
     void* _connect_cb_arg;

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -73,6 +73,8 @@ class AsyncClient {
 
     bool _pcb_busy;
 #if ASYNC_TCP_SSL_ENABLED
+    size_t _root_ca_len;
+    char* _root_ca;
     bool _pcb_secure;
     bool _handshake_done;
 #endif // ASYNC_TCP_SSL_ENABLED
@@ -119,6 +121,7 @@ class AsyncClient {
 #if ASYNC_TCP_SSL_ENABLED
     bool connect(IPAddress ip, uint16_t port, bool secure = false);
     bool connect(const char* host, uint16_t port,  bool secure = false);
+    void setRootCa(const char* rootca, const size_t len);
 #else
     bool connect(IPAddress ip, uint16_t port);
     bool connect(const char* host, uint16_t port);

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -47,7 +47,7 @@ typedef std::function<void(void*, AsyncClient*, struct pbuf *pb)> AcPacketHandle
 typedef std::function<void(void*, AsyncClient*, uint32_t time)> AcTimeoutHandler;
 
 struct tcp_pcb;
-struct _ip_addr;
+struct ip_addr;
 
 class AsyncClient {
   protected:
@@ -93,7 +93,7 @@ class AsyncClient {
 #endif // ASYNC_TCP_SSL_ENABLED
     int8_t _poll(tcp_pcb* pcb);
     int8_t _sent(tcp_pcb* pcb, uint16_t len);
-    void _dns_found(struct _ip_addr *ipaddr);
+    void _dns_found(struct ip_addr *ipaddr);
 #if ASYNC_TCP_SSL_ENABLED
     static void _s_data(void *arg, struct tcp_pcb *tcp, uint8_t * data, size_t len);
     static void _s_handshake(void *arg, struct tcp_pcb *tcp, struct tcp_ssl_pcb* ssl);
@@ -130,13 +130,13 @@ class AsyncClient {
 
     bool canSend();//ack is not pending
     size_t space();
-    size_t add(const char* data, size_t size, uint8_t apiflags=0);//add for sending
+    size_t add(const char* data, size_t size, uint8_t apiflags=ASYNC_WRITE_FLAG_COPY);//add for sending
     bool send();//send all data added with the method above
     size_t ack(size_t len); //ack data that you have not acked using the method below
     void ackLater(){ _ack_pcb = false; } //will not ack the current packet. Call from onData
 
     size_t write(const char* data);
-    size_t write(const char* data, size_t size, uint8_t apiflags=0); //only when canSend() == true
+    size_t write(const char* data, size_t size, uint8_t apiflags=ASYNC_WRITE_FLAG_COPY); //only when canSend() == true
 
     uint8_t state();
     bool connecting();
@@ -183,7 +183,7 @@ class AsyncClient {
     static void _s_error(void *arg, int8_t err);
     static int8_t _s_sent(void *arg, struct tcp_pcb *tpcb, uint16_t len);
     static int8_t _s_connected(void* arg, void* tpcb, int8_t err);
-    static void _s_dns_found(const char *name, struct _ip_addr *ipaddr, void *arg);
+    static void _s_dns_found(const char *name, struct ip_addr *ipaddr, void *arg);
 
     bool _in_lwip_thread;
 };

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -22,6 +22,7 @@
 #ifndef ASYNCTCP_H_
 #define ASYNCTCP_H_
 
+#include "Arduino.h"
 #include "IPAddress.h"
 #include <functional>
 #include <string>

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -24,6 +24,7 @@
 
 #include "IPAddress.h"
 #include <functional>
+#include <string>
 #include <ssl_client.h>
 extern "C" {
     #include "freertos/semphr.h"
@@ -70,8 +71,10 @@ class AsyncClient {
     void* _poll_cb_arg;
 
     bool _pcb_busy;
+#if ASYNC_TCP_SSL_ENABLED
     bool _pcb_secure;
     bool _handshake_done;
+#endif // ASYNC_TCP_SSL_ENABLED
     uint32_t _pcb_sent_at;
     bool _close_pcb;
     bool _ack_pcb;
@@ -84,13 +87,17 @@ class AsyncClient {
     int8_t _close();
     int8_t _connected(void* pcb, int8_t err);
     void _error(int8_t err);
+#if ASYNC_TCP_SSL_ENABLED
     void _ssl_error(int8_t err);
+#endif // ASYNC_TCP_SSL_ENABLED
     int8_t _poll(tcp_pcb* pcb);
     int8_t _sent(tcp_pcb* pcb, uint16_t len);
     void _dns_found(struct _ip_addr *ipaddr);
+#if ASYNC_TCP_SSL_ENABLED
     static void _s_data(void *arg, struct tcp_pcb *tcp, uint8_t * data, size_t len);
     static void _s_handshake(void *arg, struct tcp_pcb *tcp, struct tcp_ssl_pcb* ssl);
     static void _s_ssl_error(void *arg, struct tcp_pcb *tcp, int8_t err);
+#endif // ASYNC_TCP_SSL_ENABLED
 
   public:
     AsyncClient* prev;
@@ -107,8 +114,14 @@ class AsyncClient {
     bool operator!=(const AsyncClient &other) {
       return !(*this == other);
     }
+
+#if ASYNC_TCP_SSL_ENABLED
     bool connect(IPAddress ip, uint16_t port, bool secure = false);
     bool connect(const char* host, uint16_t port,  bool secure = false);
+#else
+    bool connect(IPAddress ip, uint16_t port);
+    bool connect(const char* host, uint16_t port);
+#endif // ASYNC_TCP_SSL_ENABLED
     void close(bool now = false);
     void stop();
     int8_t abort();

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -77,6 +77,8 @@ class AsyncClient {
     char* _root_ca;
     bool _pcb_secure;
     bool _handshake_done;
+    const char* _psk_ident;
+    const char* _psk;
 #endif // ASYNC_TCP_SSL_ENABLED
     uint32_t _pcb_sent_at;
     bool _close_pcb;
@@ -122,6 +124,7 @@ class AsyncClient {
     bool connect(IPAddress ip, uint16_t port, bool secure = false);
     bool connect(const char* host, uint16_t port,  bool secure = false);
     void setRootCa(const char* rootca, const size_t len);
+    void setPsk(const char* psk_ident, const char* psk);
 #else
     bool connect(IPAddress ip, uint16_t port);
     bool connect(const char* host, uint16_t port);

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -188,6 +188,10 @@ class AsyncClient {
     bool _in_lwip_thread;
 };
 
+#if ASYNC_TCP_SSL_ENABLED
+typedef std::function<int(void* arg, const char *filename, uint8_t **buf)> AcSSlFileHandler;
+#endif
+
 class AsyncServer {
   protected:
     uint16_t _port;
@@ -204,6 +208,11 @@ class AsyncServer {
     AsyncServer(uint16_t port);
     ~AsyncServer();
     void onClient(AcConnectHandler cb, void* arg);
+#if ASYNC_TCP_SSL_ENABLED
+    // Dummy, so it compiles with ESP Async WebServer library enabled.
+    void onSslFileRequest(AcSSlFileHandler cb, void* arg) {};
+    void beginSecure(const char *cert, const char *private_key_file, const char *password) {};
+#endif
     void begin();
     void end();
     void setNoDelay(bool nodelay);

--- a/src/tcp_mbedtls.c
+++ b/src/tcp_mbedtls.c
@@ -1,13 +1,8 @@
-#define DEBUG true
-#define CONFIG_MBEDTLS_DEBUG true
-#define DEBUG_LEVEL 4
-
 #include "tcp_mbedtls.h"
 #include "lwip/tcp.h"
 #include "mbedtls/debug.h"
 #include "mbedtls/esp_debug.h"
 #include <string.h>
-#include "mbedtls/debug.h"
 
 // #define TCP_SSL_DEBUG(...) ets_printf(__VA_ARGS__)
 #define TCP_SSL_DEBUG(...) 

--- a/src/tcp_mbedtls.c
+++ b/src/tcp_mbedtls.c
@@ -6,8 +6,8 @@
 #include "mbedtls/esp_debug.h"
 #include <string.h>
 
-#define TCP_SSL_DEBUG(...) ets_printf(__VA_ARGS__)
-// #define TCP_SSL_DEBUG(...) 
+// #define TCP_SSL_DEBUG(...) ets_printf(__VA_ARGS__)
+#define TCP_SSL_DEBUG(...) 
 
 static const char pers[] = "esp32-tls";
 

--- a/src/tcp_mbedtls.c
+++ b/src/tcp_mbedtls.c
@@ -356,7 +356,7 @@ int tcp_ssl_read(struct tcp_pcb *tcp, struct pbuf *p) {
     if(tcp_ssl->ssl_ctx.state != MBEDTLS_SSL_HANDSHAKE_OVER) {
       TCP_SSL_DEBUG("start handshake: %d\n", tcp_ssl->ssl_ctx.state);
       int ret = mbedtls_ssl_handshake(&tcp_ssl->ssl_ctx);
-      handle_error(ret);
+      //handle_error(ret);
       if(ret == 0) {
         TCP_SSL_DEBUG("Protocol is %s Ciphersuite is %s\n", mbedtls_ssl_get_version(&tcp_ssl->ssl_ctx), mbedtls_ssl_get_ciphersuite(&tcp_ssl->ssl_ctx));
 

--- a/src/tcp_mbedtls.c
+++ b/src/tcp_mbedtls.c
@@ -1,3 +1,5 @@
+#if ASYNC_TCP_SSL_ENABLED
+
 #include "tcp_mbedtls.h"
 #include "lwip/tcp.h"
 #include "mbedtls/debug.h"
@@ -451,3 +453,5 @@ void tcp_ssl_err(struct tcp_pcb *tcp, tcp_ssl_error_cb_t arg){
     item->on_error = arg;
   }
 }
+
+#endif // ASYNC_TCP_SSL_ENABLED

--- a/src/tcp_mbedtls.c
+++ b/src/tcp_mbedtls.c
@@ -1,0 +1,469 @@
+#include "tcp_mbedtls.h"
+#include "lwip/tcp.h"
+#include "mbedtls/debug.h"
+#include <string.h>
+
+#define TCP_SSL_DEBUG(...) ets_printf(__VA_ARGS__)
+
+static const char pers[] = "esp32-tls";
+
+static int handle_error(int err)
+{
+    if(err == -30848){
+        return err;
+    }
+#ifdef MBEDTLS_ERROR_C
+    char error_buf[100];
+    mbedtls_strerror(err, error_buf, 100);
+    TCP_SSL_DEBUG("%s\n", error_buf);
+#endif
+    TCP_SSL_DEBUG("MbedTLS message code: %d\n", err);
+    return err;
+}
+
+static uint8_t _tcp_ssl_has_client = 0;
+
+struct tcp_ssl_pcb {
+  struct tcp_pcb *tcp;
+  int fd;
+  mbedtls_ssl_context ssl_ctx;
+  mbedtls_ssl_config ssl_conf;
+  mbedtls_ctr_drbg_context drbg_ctx;
+  mbedtls_entropy_context entropy_ctx;
+  uint8_t type;
+  // int handshake;
+  void* arg;
+  tcp_ssl_data_cb_t on_data;
+  tcp_ssl_handshake_cb_t on_handshake;
+  tcp_ssl_error_cb_t on_error;
+  int last_wr;
+  struct pbuf *tcp_pbuf;
+  int pbuf_offset;
+  struct tcp_ssl_pcb* next;
+};
+
+typedef struct tcp_ssl_pcb tcp_ssl_t;
+
+static tcp_ssl_t * tcp_ssl_array = NULL;
+static int tcp_ssl_next_fd = 0;
+
+int tcp_ssl_recv(void *ctx, unsigned char *buf, size_t len) {
+  tcp_ssl_t *fd_data = (tcp_ssl_t*)ctx;
+  uint8_t *read_buf = NULL;
+  uint8_t *pread_buf = NULL;
+  u16_t recv_len = 0;
+
+  if(fd_data->tcp_pbuf == NULL || fd_data->tcp_pbuf->tot_len == 0) {
+    return 0;
+  }
+
+  read_buf =(uint8_t*)calloc(fd_data->tcp_pbuf->len + 1, sizeof(uint8_t));
+  pread_buf = read_buf;
+  if (pread_buf != NULL){
+    recv_len = pbuf_copy_partial(fd_data->tcp_pbuf, read_buf, len, fd_data->pbuf_offset);
+    fd_data->pbuf_offset += recv_len;
+  }
+
+  if (recv_len != 0) {
+    memcpy(buf, read_buf, recv_len);
+  }
+
+  if(len < recv_len) {
+    TCP_SSL_DEBUG("tcp_ssl_recv: got %d bytes more than expected\n", recv_len - len);
+  }
+
+  free(pread_buf);
+  pread_buf = NULL;
+
+  return recv_len;
+}
+
+int tcp_ssl_send(void *ctx, const unsigned char *buf, size_t size) {
+  if(ctx == NULL) {
+    TCP_SSL_DEBUG("tcp_ssl_send: no context set\n");
+    return -1;
+  }
+
+  if(buf == NULL) {
+    TCP_SSL_DEBUG("tcp_ssl_send: buf not set\n");
+    return -1;
+  }
+
+  tcp_ssl_t *tcp = (tcp_ssl_t*)ctx;
+  
+  size_t room = tcp_sndbuf(tcp->tcp);
+  size_t will_send = (room < size) ? room : size;
+
+  TCP_SSL_DEBUG("len: %d, has space? %d\n", size, room);
+
+  int8_t ret = tcp_write(tcp->tcp, buf, will_send, 0);
+  if(ret == ERR_OK) {
+    TCP_SSL_DEBUG("oki!\n");
+  }
+
+  return will_send;
+}
+
+uint8_t tcp_ssl_has_client() {
+  return _tcp_ssl_has_client;
+}
+
+tcp_ssl_t * tcp_ssl_new(struct tcp_pcb *tcp) {
+
+  if(tcp_ssl_next_fd < 0){
+    tcp_ssl_next_fd = 0;//overflow
+  }
+
+  tcp_ssl_t * new_item = (tcp_ssl_t*)malloc(sizeof(tcp_ssl_t));
+  if(!new_item){
+    TCP_SSL_DEBUG("tcp_ssl_new: failed to allocate tcp_ssl\n");
+    return NULL;
+  }
+
+  new_item->tcp = tcp;
+  new_item->arg = NULL;
+  new_item->on_data = NULL;
+  new_item->on_handshake = NULL;
+  new_item->on_error = NULL;
+  new_item->tcp_pbuf = NULL;
+  new_item->pbuf_offset = 0;
+  new_item->next = NULL;
+  // new_item->ssl_ctx = NULL;
+  // new_item->ssl = NULL;
+  new_item->fd = tcp_ssl_next_fd++;
+
+  if(tcp_ssl_array == NULL){
+    tcp_ssl_array = new_item;
+  } else {
+    tcp_ssl_t * item = tcp_ssl_array;
+    while(item->next != NULL)
+      item = item->next;
+    item->next = new_item;
+  }
+
+  TCP_SSL_DEBUG("tcp_ssl_new: %d: 0x%x\n", new_item->fd, tcp);
+  return new_item;
+}
+
+tcp_ssl_t* tcp_ssl_get(struct tcp_pcb *tcp) {
+  if(tcp == NULL) {
+    return NULL;
+  }
+  tcp_ssl_t * item = tcp_ssl_array;
+  while(item && item->tcp != tcp){
+    item = item->next;
+  }
+  return item;
+}
+
+int tcp_ssl_new_client(struct tcp_pcb *tcp) {
+  tcp_ssl_t* tcp_ssl;
+
+  TCP_SSL_DEBUG("tcp_ssl_new_client\n");
+
+  if(tcp == NULL) {
+    return -1;
+  }
+
+  if(tcp_ssl_get(tcp) != NULL){
+    TCP_SSL_DEBUG("tcp_ssl_new_client: tcp_ssl already exists\n");
+    return -1;
+  }
+
+  tcp_ssl = tcp_ssl_new(tcp);
+  if(tcp_ssl == NULL){
+    return -1;
+  }
+
+  // 
+  mbedtls_entropy_init(&tcp_ssl->entropy_ctx);
+  mbedtls_ctr_drbg_init(&tcp_ssl->drbg_ctx);
+  mbedtls_ssl_init(&tcp_ssl->ssl_ctx);
+  mbedtls_ssl_config_init(&tcp_ssl->ssl_conf);
+
+  mbedtls_ctr_drbg_seed(&tcp_ssl->drbg_ctx, mbedtls_entropy_func,
+                        &tcp_ssl->entropy_ctx, (const unsigned char*)pers, strlen(pers));
+
+  if(mbedtls_ssl_config_defaults(&tcp_ssl->ssl_conf,
+    MBEDTLS_SSL_IS_CLIENT,
+    MBEDTLS_SSL_TRANSPORT_STREAM,
+    MBEDTLS_SSL_PRESET_DEFAULT)) {
+    TCP_SSL_DEBUG("error setting SSL config.\n");
+    
+    // tcp_ssl_free(tcp);
+    return -1;
+  }
+
+  mbedtls_ssl_conf_authmode(&tcp_ssl->ssl_conf, MBEDTLS_SSL_VERIFY_NONE);
+  int ret = 0;
+
+  // @ToDo: there's no hostname at this stage, set it later.
+  // if((ret = mbedtls_ssl_set_hostname(&ctx->ssl_ctx, host)) != 0){
+  //   return handle_error(ret);
+  // }
+
+  mbedtls_ssl_conf_rng(&tcp_ssl->ssl_conf, mbedtls_ctr_drbg_random, &tcp_ssl->drbg_ctx);
+ 
+  if ((ret = mbedtls_ssl_setup(&tcp_ssl->ssl_ctx, &tcp_ssl->ssl_conf)) != 0) {
+    // tcp_ssl_free(tcp);
+    return handle_error(ret);
+  }
+
+  // mbedtls_ssl_set_bio(&tcp_ssl->ssl_ctx, (void*)tcp_ssl, tcp_ssl_send, tcp_ssl_recv, NULL );
+  mbedtls_ssl_set_bio(&tcp_ssl->ssl_ctx, (void*)tcp_ssl, tcp_ssl_send, tcp_ssl_recv, NULL);
+  // mbedtls_ssl_set_bio(&tcp_ssl->ssl_ctx, &tcp_ssl->fd, mbedtls_net_send, mbedtls_net_recv, NULL );
+
+  // @ToDo: do we need this here?
+  ret = mbedtls_ssl_handshake(&tcp_ssl->ssl_ctx);
+  handle_error(ret);
+  TCP_SSL_DEBUG("ret mbedtls_ssl_handshake: %d, want read: %d, write: %d\n", ret, MBEDTLS_ERR_SSL_WANT_READ, MBEDTLS_ERR_SSL_WANT_WRITE);
+  // if (ret != 0 && ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+  //   TCP_SSL_DEBUG("tcp_ssl_new_client: mbedtls_ssl_handshake: %d.\n", ret);
+  //   // if(tcp_ssl->on_error)
+  //   //   tcp_ssl->on_error(tcp_ssl->arg, tcp_ssl->tcp, ret);
+  // }
+
+  TCP_SSL_DEBUG("end tcp_ssl_new_client %d.\n", tcp_ssl->fd);
+
+  return tcp_ssl->fd;
+}
+
+int tcp_ssl_write(struct tcp_pcb *tcp, uint8_t *data, size_t len) {
+  if(tcp == NULL) {
+    return -1;
+  }
+  
+  tcp_ssl_t * tcp_ssl = tcp_ssl_get(tcp);
+
+  TCP_SSL_DEBUG("tcp_ssl_write %x\n, state: %d\n", tcp_ssl, tcp->state);
+
+  if(tcp_ssl == NULL){
+    TCP_SSL_DEBUG("tcp_ssl_write: tcp_ssl is NULL\n");
+    return 0;
+  }
+
+  tcp_ssl->last_wr = 0;
+
+  TCP_SSL_DEBUG("about to call mbedtls_ssl_write\n");
+  int rc = mbedtls_ssl_write(&tcp_ssl->ssl_ctx, data, len);
+
+  TCP_SSL_DEBUG("tcp_ssl_write: %u -> %d (%d)\r\n", len, tcp_ssl->last_wr, rc);
+
+  if (rc < 0){
+    // @ToDO: ???
+    // if(rc != MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+      TCP_SSL_DEBUG("tcp_ssl_write error: %d\r\n", rc);
+    // }
+    return rc;
+  }
+
+  return tcp_ssl->last_wr;
+}
+
+int tcp_ssl_read(struct tcp_pcb *tcp, struct pbuf *p) {
+  TCP_SSL_DEBUG("tcp_ssl_ssl_read\n");
+
+  if(tcp == NULL) {
+    return -1;
+  }
+  tcp_ssl_t* fd_data = NULL;
+
+  int read_bytes = 0;
+  int total_bytes = 0;
+  uint8_t *read_buf;
+
+  fd_data = tcp_ssl_get(tcp);
+  if(fd_data == NULL) {
+    TCP_SSL_DEBUG("tcp_ssl_read: tcp_ssl is NULL\n");
+    return ERR_TCP_SSL_INVALID_CLIENTFD_DATA;
+  }
+
+  if(p == NULL) {
+    TCP_SSL_DEBUG("tcp_ssl_read:p == NULL\n");
+    return ERR_TCP_SSL_INVALID_DATA;
+  }
+
+  TCP_SSL_DEBUG("READY TO READ SOME DATA\n");
+
+  fd_data->tcp_pbuf = p;
+  fd_data->pbuf_offset = 0;
+
+  do {    
+    if(fd_data->ssl_ctx.state != MBEDTLS_SSL_HANDSHAKE_OVER) {
+      TCP_SSL_DEBUG("start handshake: %d\n", fd_data->ssl_ctx.state);
+      int ret = mbedtls_ssl_handshake(&fd_data->ssl_ctx);
+      if(ret == 0) {
+        if(fd_data->on_handshake)
+          fd_data->on_handshake(fd_data->arg, fd_data->tcp, fd_data);
+      } else if(ret != MBEDTLS_ERR_SSL_WANT_READ || ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+        // if(fd_data->on_error)
+        //   fd_data->on_error(fd_data->arg, fd_data->tcp, ret);
+        
+        TCP_SSL_DEBUG("handshake error: %d\n", ret);
+        // return ret;
+        //return 0;
+      }
+    } else {
+      uint8_t readb[1024];
+      read_bytes = mbedtls_ssl_read(&fd_data->ssl_ctx, &readb, 1024);
+      TCP_SSL_DEBUG("start read: %d.\n", read_bytes);
+      if(read_bytes < 0) {
+        handle_error(read_bytes);
+        if(read_bytes != MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+          TCP_SSL_DEBUG("tcp_ssl_read: read error: %d\n", read_bytes);
+        }
+        total_bytes = read_bytes;
+        break;
+      } else if(read_bytes > 0) {
+        if(fd_data->on_data){
+          fd_data->on_data(fd_data->arg, tcp, &readb, read_bytes);
+        }
+        total_bytes+= read_bytes;
+      }
+    }
+    //   if(fd_data->ssl_ctx.state != MBEDTLS_SSL_HANDSHAKE_OVER) {
+    //     TCP_SSL_DEBUG("start handshake.\n");
+    //     int ret = mbedtls_ssl_handshake(&fd_data->ssl_ctx);
+    //     if(ret == 0) {
+    //       if(fd_data->on_handshake)
+    //         fd_data->on_handshake(fd_data->arg, fd_data->tcp, fd_data);
+    //     } else if(ret != MBEDTLS_ERR_SSL_WANT_READ || ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+    //       if(fd_data->on_error)
+    //         fd_data->on_error(fd_data->arg, fd_data->tcp, ret);
+    //       return ret;
+    //     }
+    //   } 
+    // // @TODO: FIX!
+    // read_bytes = mbedtls_ssl_read(&fd_data->ssl_ctx, &read_buf, 0);
+    // TCP_SSL_DEBUG("tcp_ssl_ssl_read: read_bytes: %d (%d)\n", read_bytes, MBEDTLS_SSL_HANDSHAKE_OVER);
+    // if(read_bytes < 0) {
+    //   handle_error(read_bytes);
+    //   if(read_bytes != MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY) {
+    //     TCP_SSL_DEBUG("tcp_ssl_read: read error: %d\n", read_bytes);
+    //   }
+    //   total_bytes = read_bytes;
+    //   break;
+    // } else if(read_bytes > 0){
+    //   if(fd_data->on_data){
+    //     fd_data->on_data(fd_data->arg, tcp, read_buf, read_bytes);
+    //   }
+    //   total_bytes+= read_bytes;
+    // } else {
+    //   TCP_SSL_DEBUG("start handshake? %d.\n", fd_data->ssl_ctx.state);
+    //   if(fd_data->ssl_ctx.state != MBEDTLS_SSL_HANDSHAKE_OVER) {
+    //     TCP_SSL_DEBUG("start handshake.\n");
+    //     int ret = mbedtls_ssl_handshake(&fd_data->ssl_ctx);
+    //     if(ret == 0) {
+    //       if(fd_data->on_handshake)
+    //         fd_data->on_handshake(fd_data->arg, fd_data->tcp, fd_data);
+    //     } else if(ret != MBEDTLS_ERR_SSL_WANT_READ || ret != MBEDTLS_ERR_SSL_WANT_WRITE) {
+    //       if(fd_data->on_error)
+    //         fd_data->on_error(fd_data->arg, fd_data->tcp, ret);
+    //       return ret;
+    //     }
+    //   } 
+    // }
+  } while (p->tot_len - fd_data->pbuf_offset > 0);
+     
+  // OLD     
+  // if(fd_data->handshake != MBEDTLS_SSL_HANDSHAKE_OVER) {
+  //   fd_data->handshake = mbedtls_ssl_handshake(&fd_data->ssl_ctx);
+  //   if(fd_data->handshake == 0){
+  //     TCP_SSL_DEBUG("tcp_ssl_read: handshake OK\n");
+  //     if(fd_data->on_handshake)
+  //       fd_data->on_handshake(fd_data->arg, fd_data->tcp, fd_data);
+  //   } else if(fd_data->handshake != 0){
+  //     TCP_SSL_DEBUG("tcp_ssl_read: handshake error: %d\n", fd_data->handshake);
+  //     if(fd_data->on_error)
+  //       fd_data->on_error(fd_data->arg, fd_data->tcp, fd_data->handshake);
+  //     return fd_data->handshake;
+  //   }
+  // }
+
+  tcp_recved(tcp, p->tot_len);
+  fd_data->tcp_pbuf = NULL;
+  pbuf_free(p);
+
+  TCP_SSL_DEBUG("tcp_ssl_read: eof: %d\n", total_bytes);
+
+  return total_bytes;
+}
+
+int tcp_ssl_free(struct tcp_pcb *tcp) {
+  TCP_SSL_DEBUG("tcp_ssl_free: 1\n");
+  if(tcp == NULL) {
+    return -1;
+  }
+  TCP_SSL_DEBUG("tcp_ssl_free: 2\n");
+  tcp_ssl_t * item = tcp_ssl_array;
+  TCP_SSL_DEBUG("tcp_ssl_free: 2a 0x%x\n", item);
+  if(item->tcp == tcp){
+    TCP_SSL_DEBUG("tcp_ssl_free: 3\n");
+    tcp_ssl_array = tcp_ssl_array->next;
+    if(item->tcp_pbuf != NULL) {
+      pbuf_free(item->tcp_pbuf);
+    }
+    TCP_SSL_DEBUG("tcp_ssl_free: %d\n", item->fd);
+    mbedtls_ssl_free(&item->ssl_ctx);
+    mbedtls_ssl_config_free(&item->ssl_conf);
+    mbedtls_ctr_drbg_free(&item->drbg_ctx);
+    mbedtls_entropy_free(&item->entropy_ctx);
+    free(item);
+    return 0;
+  }
+
+  TCP_SSL_DEBUG("tcp_ssl_free: 4\n");
+  while(item->next && item->next->tcp != tcp)
+    item = item->next;
+
+  TCP_SSL_DEBUG("tcp_ssl_free: 5\n");
+  if(item->next == NULL){
+    return ERR_TCP_SSL_INVALID_CLIENTFD_DATA;//item not found
+  }
+  TCP_SSL_DEBUG("tcp_ssl_free: 6\n");
+  tcp_ssl_t * i = item->next;
+  item->next = i->next;
+  if(i->tcp_pbuf != NULL){
+    pbuf_free(i->tcp_pbuf);
+  }
+  TCP_SSL_DEBUG("tcp_ssl_free: %d\n", i->fd);
+  mbedtls_ssl_free(&i->ssl_ctx);
+  mbedtls_ssl_config_free(&i->ssl_conf);
+  mbedtls_ctr_drbg_free(&i->drbg_ctx);
+  mbedtls_entropy_free(&i->entropy_ctx);
+  free(i);
+
+  return 0;
+}
+
+bool tcp_ssl_has(struct tcp_pcb *tcp) {
+  return tcp_ssl_get(tcp) != NULL;
+}
+
+void tcp_ssl_arg(struct tcp_pcb *tcp, void * arg) {
+  tcp_ssl_t * item = tcp_ssl_get(tcp);
+  if(item) {
+    item->arg = arg;
+  }
+}
+
+void tcp_ssl_data(struct tcp_pcb *tcp, tcp_ssl_data_cb_t arg){
+  tcp_ssl_t * item = tcp_ssl_get(tcp);
+  if(item) {
+    item->on_data = arg;
+  }
+}
+
+void tcp_ssl_handshake(struct tcp_pcb *tcp, tcp_ssl_handshake_cb_t arg){
+  tcp_ssl_t * item = tcp_ssl_get(tcp);
+  if(item) {
+    item->on_handshake = arg;
+  }
+}
+
+void tcp_ssl_err(struct tcp_pcb *tcp, tcp_ssl_error_cb_t arg){
+  tcp_ssl_t * item = tcp_ssl_get(tcp);
+  if(item) {
+    item->on_error = arg;
+  }
+}

--- a/src/tcp_mbedtls.h
+++ b/src/tcp_mbedtls.h
@@ -1,6 +1,8 @@
 #ifndef LWIPR_MBEDTLS_H
 #define LWIPR_MBEDTLS_H
 
+#if ASYNC_TCP_SSL_ENABLED
+
 #include "mbedtls/platform.h"
 #include "mbedtls/net.h"
 #include "mbedtls/debug.h"
@@ -45,3 +47,4 @@ void tcp_ssl_err(struct tcp_pcb *tcp, tcp_ssl_error_cb_t arg);
 
 
 #endif // LWIPR_MBEDTLS_H
+#endif // ASYNC_TCP_SSL_ENABLED

--- a/src/tcp_mbedtls.h
+++ b/src/tcp_mbedtls.h
@@ -31,6 +31,7 @@ typedef void (* tcp_ssl_error_cb_t)(void *arg, struct tcp_pcb *tcp, int8_t error
 
 uint8_t tcp_ssl_has_client();
 int tcp_ssl_new_client(struct tcp_pcb *tcp, const char* hostname, const char* root_ca, const size_t root_ca_len);
+int tcp_ssl_new_psk_client(struct tcp_pcb *tcp, const char* psk_ident, const char* psk);
 int tcp_ssl_write(struct tcp_pcb *tcp, uint8_t *data, size_t len);
 int tcp_ssl_read(struct tcp_pcb *tcp, struct pbuf *p);
 int tcp_ssl_handshake_step(struct tcp_pcb *tcp);

--- a/src/tcp_mbedtls.h
+++ b/src/tcp_mbedtls.h
@@ -28,9 +28,10 @@ typedef void (* tcp_ssl_handshake_cb_t)(void *arg, struct tcp_pcb *tcp, struct t
 typedef void (* tcp_ssl_error_cb_t)(void *arg, struct tcp_pcb *tcp, int8_t error);
 
 uint8_t tcp_ssl_has_client();
-int tcp_ssl_new_client(struct tcp_pcb *tcp);
+int tcp_ssl_new_client(struct tcp_pcb *tcp, const char* hostname);
 int tcp_ssl_write(struct tcp_pcb *tcp, uint8_t *data, size_t len);
 int tcp_ssl_read(struct tcp_pcb *tcp, struct pbuf *p);
+int tcp_ssl_handshake_step(struct tcp_pcb *tcp);
 int tcp_ssl_free(struct tcp_pcb *tcp);
 bool tcp_ssl_has(struct tcp_pcb *tcp);
 void tcp_ssl_arg(struct tcp_pcb *tcp, void * arg);

--- a/src/tcp_mbedtls.h
+++ b/src/tcp_mbedtls.h
@@ -30,7 +30,7 @@ typedef void (* tcp_ssl_handshake_cb_t)(void *arg, struct tcp_pcb *tcp, struct t
 typedef void (* tcp_ssl_error_cb_t)(void *arg, struct tcp_pcb *tcp, int8_t error);
 
 uint8_t tcp_ssl_has_client();
-int tcp_ssl_new_client(struct tcp_pcb *tcp, const char* hostname);
+int tcp_ssl_new_client(struct tcp_pcb *tcp, const char* hostname, const char* root_ca, const size_t root_ca_len);
 int tcp_ssl_write(struct tcp_pcb *tcp, uint8_t *data, size_t len);
 int tcp_ssl_read(struct tcp_pcb *tcp, struct pbuf *p);
 int tcp_ssl_handshake_step(struct tcp_pcb *tcp);

--- a/src/tcp_mbedtls.h
+++ b/src/tcp_mbedtls.h
@@ -1,0 +1,46 @@
+#ifndef LWIPR_MBEDTLS_H
+#define LWIPR_MBEDTLS_H
+
+#include "mbedtls/platform.h"
+#include "mbedtls/net.h"
+#include "mbedtls/debug.h"
+#include "mbedtls/ssl.h"
+#include "mbedtls/entropy.h"
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ERR_TCP_SSL_INVALID_SSL           -101
+#define ERR_TCP_SSL_INVALID_TCP           -102
+#define ERR_TCP_SSL_INVALID_CLIENTFD      -103
+#define ERR_TCP_SSL_INVALID_CLIENTFD_DATA -104
+#define ERR_TCP_SSL_INVALID_DATA          -105
+
+struct tcp_pcb;
+struct pbuf;
+struct tcp_ssl_pcb;
+
+typedef void (* tcp_ssl_data_cb_t)(void *arg, struct tcp_pcb *tcp, uint8_t * data, size_t len);
+typedef void (* tcp_ssl_handshake_cb_t)(void *arg, struct tcp_pcb *tcp, struct tcp_ssl_pcb* ssl);
+typedef void (* tcp_ssl_error_cb_t)(void *arg, struct tcp_pcb *tcp, int8_t error);
+
+uint8_t tcp_ssl_has_client();
+int tcp_ssl_new_client(struct tcp_pcb *tcp);
+int tcp_ssl_write(struct tcp_pcb *tcp, uint8_t *data, size_t len);
+int tcp_ssl_read(struct tcp_pcb *tcp, struct pbuf *p);
+int tcp_ssl_free(struct tcp_pcb *tcp);
+bool tcp_ssl_has(struct tcp_pcb *tcp);
+void tcp_ssl_arg(struct tcp_pcb *tcp, void * arg);
+void tcp_ssl_data(struct tcp_pcb *tcp, tcp_ssl_data_cb_t arg);
+void tcp_ssl_handshake(struct tcp_pcb *tcp, tcp_ssl_handshake_cb_t arg);
+void tcp_ssl_err(struct tcp_pcb *tcp, tcp_ssl_error_cb_t arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif // LWIPR_MBEDTLS_H


### PR DESCRIPTION
This is a tentative PR to replace #43 to account for the significant restructuring that was made on master since that PR.
This still only has client-side TLS support.
More testing is required before this can be considered for merging, I wanted to get this queued-up in case someone else is also working on this to avoid duplication of effort.