### PR TITLE
Fix Issue that connect() did not work with DNS

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -161,6 +161,9 @@ static void _handle_async_event(lwip_event_packet_t * e){
     } else if(e->event == LWIP_TCP_ACCEPT){
         //ets_printf("A: 0x%08x 0x%08x\n", e->arg, e->accept.client);
         AsyncServer::_s_accepted(e->arg, e->accept.client);
+    } else if(e->event == LWIP_TCP_DNS){
+        //ets_printf("D: 0x%08x %s = %s\n", e->arg, e->dns.name, ipaddr_ntoa(&e->dns.addr));
+        AsyncClient::_s_dns_found(e->dns.name, &e->dns.addr, e->arg);
     }
     free((void*)(e));
 }
@@ -674,6 +677,13 @@ bool AsyncClient::connect(IPAddress ip, uint16_t port){
 
 bool AsyncClient::connect(const char* host, uint16_t port){
     ip_addr_t addr;
+    
+    if(!_start_async_task()){
+      Serial.println("failed to start task");
+      log_e("failed to start task");
+      return false;
+    }
+    
     err_t err = dns_gethostbyname(host, &addr, (dns_found_callback)&_tcp_dns_found, this);
     if(err == ERR_OK) {
         return connect(IPAddress(addr.u_addr.ip4.addr), port);


### PR DESCRIPTION
Add additional code to `bool AsyncClient::connect(const char* host, uint16_t port)` and `static void _handle_async_event(lwip_event_packet_t * e)`.

1) Async Service task and queue has not yet been started when `dns_gethostbyname` yields an IP address with the callback `_tcp_dns_found`.  Fixing this with `_start_async_task()` before calling DNS.

2) No handler is defined for ` LWIP_TCP_DNS`. Fixing this with adding `else if (e->event == LWIP_TCP_DNS)` and calling `AsyncClient::_s_dns_found(e->dns.name, &e->dns.addr, e->arg)`