### PR TITLE
Add CMakeLists.txt file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(COMPONENT_SRCDIRS
+    "src"
+)
+
+set(COMPONENT_ADD_INCLUDEDIRS
+    "src"
+)
+
+set(COMPONENT_REQUIRES
+    "arduino-esp32"
+)
+
+register_component()
+
+target_compile_options(${COMPONENT_TARGET} PRIVATE -fno-rtti)


### PR DESCRIPTION
Create `CMakeLists.txt` file to match `component.mk` for ESP-IDF with CMake.