### PR TITLE
Fix assertion errors

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -847,7 +847,7 @@ int8_t AsyncClient::_connected(void* pcb, int8_t err){
 void AsyncClient::_error(int8_t err) {
     if(_pcb){
         tcp_arg(_pcb, NULL);
-		if(_pcb->state == LISTEN) {
+        if(_pcb->state == LISTEN) {
             tcp_sent(_pcb, NULL);
             tcp_recv(_pcb, NULL);
             tcp_err(_pcb, NULL);

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -847,10 +847,6 @@ int8_t AsyncClient::_connected(void* pcb, int8_t err){
 void AsyncClient::_error(int8_t err) {
     if(_pcb){
         tcp_arg(_pcb, NULL);
-        tcp_sent(_pcb, NULL);
-        tcp_recv(_pcb, NULL);
-        tcp_err(_pcb, NULL);
-        tcp_poll(_pcb, NULL, 0);
         _pcb = NULL;
     }
     if(_error_cb) {
@@ -868,10 +864,12 @@ int8_t AsyncClient::_lwip_fin(tcp_pcb* pcb, int8_t err) {
         return ERR_OK;
     }
     tcp_arg(_pcb, NULL);
-    tcp_sent(_pcb, NULL);
-    tcp_recv(_pcb, NULL);
-    tcp_err(_pcb, NULL);
-    tcp_poll(_pcb, NULL, 0);
+    if(_pcb->state == LISTEN) {
+        tcp_sent(_pcb, NULL);
+        tcp_recv(_pcb, NULL);
+        tcp_err(_pcb, NULL);
+        tcp_poll(_pcb, NULL, 0);
+    }
     if(tcp_close(_pcb) != ERR_OK) {
         tcp_abort(_pcb);
     }

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -847,6 +847,12 @@ int8_t AsyncClient::_connected(void* pcb, int8_t err){
 void AsyncClient::_error(int8_t err) {
     if(_pcb){
         tcp_arg(_pcb, NULL);
+		if(_pcb->state == LISTEN) {
+            tcp_sent(_pcb, NULL);
+            tcp_recv(_pcb, NULL);
+            tcp_err(_pcb, NULL);
+            tcp_poll(_pcb, NULL, 0);
+        }
         _pcb = NULL;
     }
     if(_error_cb) {


### PR DESCRIPTION
I don't know if it is correct.

For my project I'm using the [Async Event Source Plugin](https://github.com/me-no-dev/ESPAsyncWebServer#async-event-source-plugin) from [ESPAsyncWebServer](https://github.com/me-no-dev/ESPAsyncWebServer).

My client contained a bug that initialized a [SSE](https://en.wikipedia.org/wiki/Server-sent_events) connection every second. After some time my ESP32 crashes and reboots. Needless to say I had to fix that bug in my client.

But from my opinion, the server should not crash/reboot from that issue. So I tried to pin point the problem.

A little background, when a SSE client connects, a welcome message is send back:
```cpp
void Events::onLocalWebSocketConnected(AsyncEventSourceClient *client) {
    client->send("welcome", "message", getId());
}
```

First I wrote a python script that simulates my client bug. (Connect every second to the ESP32, for 500 times)
```python
from sseclient import SSEClient
import threading
import time

def main():
    for x in range(0, 500):
        print("Connnection %d" % x)
        x = threading.Thread(target=sseClient)
        x.start()
        time.sleep(1)

def sseClient():
    messages = SSEClient('http://{ip}/events')

if __name__ == "__main__":
    main()
```

And indeed after some time the ESP32 crashes. ~~I figured out that there where 2 issues. 1 is [ESPAsyncWebServer](https://github.com/me-no-dev/ESPAsyncWebServer) related (I will open a pull request for that too) and 1 is AsyncTCP related.~~

The error that occurred that is AsyncTCP related:
`assertion "invalid socket state for sent callback" failed: file "/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/lwip/src/core/tcp.c", line 1842, function: tcp_sent`

```
0x4008e2dc: invoke_abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/panic.c line 155
0x4008e50d: abort at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/panic.c line 170
0x401214bb: __assert_func at ../../../.././newlib/libc/stdlib/assert.c line 63
0x4013b6da: tcp_sent at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/lwip/lwip/src/core/tcp.c line 1842
0x40176640: AsyncClient::_error(signed char) at .pio\libdeps\development\AsyncTCP\src\AsyncTCP.cpp line 851
0x4017694b: _async_service_task(void*) at .pio\libdeps\development\AsyncTCP\src\AsyncTCP.cpp line 1211
0x4008a991: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c line 143

```

The problem was that an error occurred and the socket state was not `LISTEN`. When `tcp_sent` is called without the state `LISTEN`, an [assertion error is thrown](https://github.com/espressif/esp-lwip/blob/5d80af7d59c10b7890f0fc862e4efe807ce5fb73/src/core/tcp.c#L1842). 