### PR TITLE
Fix LoadProhibited

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -152,7 +152,10 @@ static bool _remove_events_with_arg(void * arg){
 }
 
 static void _handle_async_event(lwip_event_packet_t * e){
-    if(e->event == LWIP_TCP_CLEAR){
+    if(e->arg == NULL){
+        // do nothing when arg is NULL
+        //ets_printf("event arg == NULL: 0x%08x\n", e->recv.pcb);
+    } else if(e->event == LWIP_TCP_CLEAR){
         _remove_events_with_arg(e->arg);
     } else if(e->event == LWIP_TCP_RECV){
         //ets_printf("-R: 0x%08x\n", e->recv.pcb);


### PR DESCRIPTION
For my project I'm using the [Async Event Source Plugin](https://github.com/me-no-dev/ESPAsyncWebServer#async-event-source-plugin) from [ESPAsyncWebServer](https://github.com/me-no-dev/ESPAsyncWebServer).

When a client is disconnects the following error occurs:

Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.
```
Core 1 register dump:
PC      : 0x4017667f  PS      : 0x00060d30  A0      : 0x80176794  A1      : 0x3ffe8270  
A2      : 0x00000000  A3      : 0x3ffd98c0  A4      : 0x40085ff0  A5      : 0x00000001  
A6      : 0x00060d20  A7      : 0x00000000  A8      : 0x8008bb10  A9      : 0x3ffe8260  
A10     : 0x00000003  A11     : 0x00060f23  A12     : 0x00060f20  A13     : 0x0000000c  
A14     : 0x3ffdae48  A15     : 0x00000000  SAR     : 0x0000000a  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x00000004  LBEG    : 0x4000c46c  LEND    : 0x4000c477  LCOUNT  : 0xffffffff  

Backtrace: 0x4017667f:0x3ffe8270 0x40176791:0x3ffe82a0 0x4017691f:0x3ffe82c0 0x4008a991:0x3ffe82f0
```
Decoded stack results:
```
0x4017667f: AsyncClient::_poll(tcp_pcb*) at .pio\libdeps\development\AsyncTCP\src\AsyncTCP.cpp line 945
0x40176791: AsyncClient::_s_poll(void*, tcp_pcb*) at .pio\libdeps\development\AsyncTCP\src\AsyncTCP.cpp line 1203
0x4017691f: _async_service_task(void*) at .pio\libdeps\development\AsyncTCP\src\AsyncTCP.cpp line 168
0x4008a991: vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c line 143
```

This crash happens when arg is NULL. 