### PR TITLE
Make task priority configurable

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -218,7 +218,7 @@ static bool _start_async_task(){
         return false;
     }
     if(!_async_service_task_handle){
-        xTaskCreateUniversal(_async_service_task, "async_tcp", 8192 * 2, NULL, 3, &_async_service_task_handle, CONFIG_ASYNC_TCP_RUNNING_CORE);
+        xTaskCreateUniversal(_async_service_task, "async_tcp", 8192 * 2, NULL, CONFIG_ASYNC_TCP_TASK_PRIORITY, &_async_service_task_handle, CONFIG_ASYNC_TCP_RUNNING_CORE);
         if(!_async_service_task_handle){
             return false;
         }

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -36,6 +36,10 @@ extern "C" {
 #define CONFIG_ASYNC_TCP_USE_WDT 1 //if enabled, adds between 33us and 200us per event
 #endif
 
+#ifndef CONFIG_ASYNC_TCP_TASK_PRIORITY
+#define CONFIG_ASYNC_TCP_TASK_PRIORITY 3
+#endif
+
 class AsyncClient;
 
 #define ASYNC_MAX_ACK_TIME 5000


### PR DESCRIPTION
Also referring back to https://github.com/espressif/arduino-esp32/pull/4131.

TCP task priority ought to be configurable, especially with UDP task priority defaulting to the same value. A user may want to take a choice to priorize one over the other, or to have more room for his own vtask priorities below TCP beyond 0-2.
