### PR TITLE
Fix CI

### DIFF
--- a/.github/scripts/install-platformio.sh
+++ b/.github/scripts/install-platformio.sh
@@ -22,7 +22,7 @@ function build_pio_sketch(){ # build_pio_sketch <board> <path-to-ino>
 	local sketch_dir=$(dirname "$sketch")
 	echo ""
 	echo "Compiling '"$(basename "$sketch")"' ..."
-	python -m platformio ci -l '.' --board "$board" "$sketch_dir" --project-option="board_build.partitions = huge_app.csv"
+	python -m platformio ci -l '.' -l "$HOME/ESPAsyncWebServer" --board "$board" "$sketch_dir" --project-option="board_build.partitions = huge_app.csv"
 }
 
 function count_sketches() # count_sketches <examples-path>

--- a/.github/scripts/on-push.sh
+++ b/.github/scripts/on-push.sh
@@ -53,11 +53,11 @@ else
 
 	if [[ "$OSTYPE" != "cygwin" ]] && [[ "$OSTYPE" != "msys" ]] && [[ "$OSTYPE" != "win32" ]]; then
 		echo "Installing ESPAsyncWebServer ..."
-		python -m platformio lib -g install https://github.com/me-no-dev/ESPAsyncWebServer.git > /dev/null 2>&1
+		# python -m platformio lib -g install https://github.com/me-no-dev/ESPAsyncWebServer.git > /dev/null 2>&1
 		git clone https://github.com/me-no-dev/ESPAsyncWebServer "$HOME/ESPAsyncWebServer" > /dev/null 2>&1
 
-		echo "Installing ArduinoJson ..."
-		python -m platformio lib -g install https://github.com/bblanchon/ArduinoJson.git > /dev/null 2>&1
+		# echo "Installing ArduinoJson ..."
+		# python -m platformio lib -g install https://github.com/bblanchon/ArduinoJson.git > /dev/null 2>&1
 
 		build_pio_sketches "$BOARD" "$HOME/ESPAsyncWebServer/examples"
 	fi


### PR DESCRIPTION
There seems to be a bug in Platformio in handling the dependencies that are present in platform packages but not available in the Platformio Registry. In this particular case it's about the `Hash` library. This bug was preventing the installation of `ESPAsyncWebServer` as a global library. To mitigate this I commented out installations of `ArduinoJson` and `ESPAsyncWebServer` as global libraries and added path to `ESPAsyncWebServer`'s clone directory to the `platformio ci` command. Not the installation of `ESPAsyncWebServer` happend where platform package is already installed thus `Hash` library is present.

If you have any questions about this fix, feel free to ask.