### PR TITLE
Add option to configure TCP keepalives

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -1057,6 +1057,18 @@ bool AsyncClient::getNoDelay(){
     return tcp_nagle_disabled(_pcb);
 }
 
+void AsyncClient::setKeepAlive(uint32_t ms, uint8_t cnt){
+    if(ms!=0) {
+        _pcb->so_options |= SOF_KEEPALIVE; //Turn on TCP Keepalive for the given pcb
+        // Set the time between keepalive messages in milli-seconds
+        _pcb->keep_idle = ms;
+        _pcb->keep_intvl = ms;
+        _pcb->keep_cnt = cnt; //The number of unanswered probes required to force closure of the socket
+    } else {
+        _pcb->so_options &= ~SOF_KEEPALIVE; //Turn off TCP Keepalive for the given pcb
+    }
+}
+
 uint16_t AsyncClient::getMss(){
     if(!_pcb) {
         return 0;

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -99,6 +99,8 @@ class AsyncClient {
     void setNoDelay(bool nodelay);
     bool getNoDelay();
 
+    void setKeepAlive(uint32_t ms, uint8_t cnt);
+
     uint32_t getRemoteAddress();
     uint16_t getRemotePort();
     uint32_t getLocalAddress();


### PR DESCRIPTION
Exposes LWIP functionality to enable TCP keepalives. Provides methods in AsyncClient to read and set keepalive configuration.

Implements and resolves https://github.com/me-no-dev/AsyncTCP/issues/114