### PR TITLE
WDT is not dependent on which core we are running on

### DIFF
--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -33,6 +33,10 @@ extern "C" {
 //If core is not defined, then we are running in Arduino or PIO
 #ifndef CONFIG_ASYNC_TCP_RUNNING_CORE
 #define CONFIG_ASYNC_TCP_RUNNING_CORE -1 //any available core
+#endif
+
+//Watchdog Timer is not dependent on the running core
+#ifndef CONFIG_ASYNC_TCP_USE_WDT
 #define CONFIG_ASYNC_TCP_USE_WDT 1 //if enabled, adds between 33us and 200us per event
 #endif
 


### PR DESCRIPTION
This change prevents setting WDT enable flag just because the target core was not specified.  A project may want to use any core for TCP processing but not enable WDT.