### PR TITLE
Collected other pull request and Fixbug memory leaks and weakness argument pointer for tcp/ip callback function

### DIFF
--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -26,5 +26,13 @@ config ASYNC_TCP_USE_WDT
     default "y"
     help
         Enable WDT for the AsyncTCP task, so it will trigger if a handler is locking the thread.
+        
+config ASYNC_TCP_STACK
+    int "Stack size for the AsyncTCP task"
+    default 16384
+
+config ASYNC_TCP_QUEUE_SIZE
+    int "Events queue size"
+    default 32       
 
 endmenu

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -1017,8 +1017,11 @@ size_t AsyncClient::write(const char* data) {
 
 size_t AsyncClient::write(const char* data, size_t size, uint8_t apiflags) {
     size_t will_send = add(data, size, apiflags);
-    if(!will_send || !send()) {
+    if (!will_send) {
         return 0;
+    }
+    while (connected() && !send()) {
+        taskYIELD();
     }
     return will_send;
 }

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -32,8 +32,8 @@ extern "C"{
 #include "esp_task_wdt.h"
 
 #define CONFIG_ASYNC_TCP_STACK      2*8192
-#define CONFIG_ASYNC_TCP_PRIORITY   10
-#define CONFIG_ASYNC_TCP_QUEUE_SIZE 64
+#define CONFIG_ASYNC_TCP_PRIORITY   3
+#define CONFIG_ASYNC_TCP_QUEUE_SIZE 128
 
 #define ASYNC_TCP_PRINTFLN(f_, ...) Serial.printf_P(PSTR(f_ "\r\n"), ##__VA_ARGS__)
 #define ASYNC_TCP_TAG_CONSOLE(...)  ASYNC_TCP_PRINTFLN("[AsyncTCP]" __VA_ARGS__)

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -95,7 +95,7 @@ static uint32_t _closed_index = []() {
 
 static inline bool _init_async_event_queue(){
     if(!_async_queue){
-        _async_queue = xQueueCreate(32, sizeof(lwip_event_packet_t *));
+        _async_queue = xQueueCreate(CONFIG_ASYNC_TCP_QUEUE_SIZE, sizeof(lwip_event_packet_t *));
         if(!_async_queue){
             return false;
         }
@@ -218,7 +218,7 @@ static bool _start_async_task(){
         return false;
     }
     if(!_async_service_task_handle){
-        xTaskCreateUniversal(_async_service_task, "async_tcp", 8192 * 2, NULL, 3, &_async_service_task_handle, CONFIG_ASYNC_TCP_RUNNING_CORE);
+        xTaskCreateUniversal(_async_service_task, "async_tcp", CONFIG_ASYNC_TCP_STACK, NULL, 3, &_async_service_task_handle, CONFIG_ASYNC_TCP_RUNNING_CORE);
         if(!_async_service_task_handle){
             return false;
         }

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -1261,6 +1261,11 @@ void AsyncServer::onClient(AcConnectHandler cb, void* arg){
     _connect_cb_arg = arg;
 }
 
+void AsyncServer::port(uint16_t port)
+{
+    _port = port;
+}
+
 void AsyncServer::begin(){
     if(_pcb) {
         return;

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -1060,6 +1060,18 @@ bool AsyncClient::getNoDelay(){
     return tcp_nagle_disabled(_pcb);
 }
 
+void AsyncClient::setKeepAlive(uint32_t ms, uint8_t cnt){
+    if(ms!=0) {
+        _pcb->so_options |= SOF_KEEPALIVE; //Turn on TCP Keepalive for the given pcb
+        // Set the time between keepalive messages in milli-seconds
+        _pcb->keep_idle = ms;
+        _pcb->keep_intvl = ms;
+        _pcb->keep_cnt = cnt; //The number of unanswered probes required to force closure of the socket
+    } else {
+        _pcb->so_options &= ~SOF_KEEPALIVE; //Turn off TCP Keepalive for the given pcb
+    }
+}
+
 uint16_t AsyncClient::getMss(){
     if(!_pcb) {
         return 0;

--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -939,8 +939,8 @@ int8_t AsyncClient::_recv(tcp_pcb* pcb, pbuf* pb, int8_t err) {
             } else if(_pcb) {
                 _tcp_recved(_pcb, _closed_slot, b->len);
             }
-            pbuf_free(b);
         }
+        pbuf_free(b);
     }
     return ERR_OK;
 }

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -34,7 +34,7 @@ extern "C" {
 //If core is not defined, then we are running in Arduino or PIO
 #ifndef CONFIG_ASYNC_TCP_RUNNING_CORE
 #define CONFIG_ASYNC_TCP_RUNNING_CORE -1 //any available core
-#define CONFIG_ASYNC_TCP_USE_WDT      0 //if enabled, adds between 33us and 200us per event
+#define CONFIG_ASYNC_TCP_USE_WDT      1 //if enabled, adds between 33us and 200us per event
 #endif
 
 class AsyncClient;

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -35,6 +35,12 @@ extern "C" {
 #define CONFIG_ASYNC_TCP_RUNNING_CORE -1 //any available core
 #define CONFIG_ASYNC_TCP_USE_WDT 1 //if enabled, adds between 33us and 200us per event
 #endif
+#ifndef CONFIG_ASYNC_TCP_STACK
+#define CONFIG_ASYNC_TCP_STACK 8192 * 2
+#endif
+#ifndef CONFIG_ASYNC_TCP_QUEUE_SIZE
+#define CONFIG_ASYNC_TCP_QUEUE_SIZE 32
+#endif
 
 class AsyncClient;
 

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -191,6 +191,7 @@ class AsyncServer {
     AsyncServer(uint16_t port);
     ~AsyncServer();
     void onClient(AcConnectHandler cb, void* arg);
+    void port(uint16_t port);
     void begin();
     void end();
     void setNoDelay(bool nodelay);

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -34,7 +34,7 @@ extern "C" {
 //If core is not defined, then we are running in Arduino or PIO
 #ifndef CONFIG_ASYNC_TCP_RUNNING_CORE
 #define CONFIG_ASYNC_TCP_RUNNING_CORE -1 //any available core
-#define CONFIG_ASYNC_TCP_USE_WDT 1 //if enabled, adds between 33us and 200us per event
+#define CONFIG_ASYNC_TCP_USE_WDT      0 //if enabled, adds between 33us and 200us per event
 #endif
 
 class AsyncClient;
@@ -135,7 +135,7 @@ class AsyncClient {
     static int8_t _s_lwip_fin(void *arg, struct tcp_pcb *tpcb, int8_t err);
     static void _s_error(void *arg, int8_t err);
     static int8_t _s_sent(void *arg, struct tcp_pcb *tpcb, uint16_t len);
-    static int8_t _s_connected(void* arg, void* tpcb, int8_t err);
+    static int8_t _s_connected(void* arg, struct tcp_pcb *tpcb, int8_t err);
     static void _s_dns_found(const char *name, struct ip_addr *ipaddr, void *arg);
 
     int8_t _recv(tcp_pcb* pcb, pbuf* pb, int8_t err);
@@ -173,8 +173,8 @@ class AsyncClient {
 
     int8_t _close();
     void _free_closed_slot();
-    void _allocate_closed_slot();
-    int8_t _connected(void* pcb, int8_t err);
+    boolean _allocate_closed_slot();
+    int8_t _connected(tcp_pcb* pcb, int8_t err);
     void _error(int8_t err);
     int8_t _poll(tcp_pcb* pcb);
     int8_t _sent(tcp_pcb* pcb, uint16_t len);

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -99,6 +99,7 @@ class AsyncClient {
     void setNoDelay(bool nodelay);
     bool getNoDelay();
 
+    void setKeepAlive(uint32_t ms, uint8_t cnt);
     uint32_t getRemoteAddress();
     uint16_t getRemotePort();
     uint32_t getLocalAddress();

--- a/src/AsyncTCP.h
+++ b/src/AsyncTCP.h
@@ -26,6 +26,7 @@
 #include "sdkconfig.h"
 #include <functional>
 extern "C" {
+    #include "freertos/FreeRTOS.h"
     #include "freertos/semphr.h"
     #include "lwip/pbuf.h"
 }
@@ -34,12 +35,6 @@ extern "C" {
 #ifndef CONFIG_ASYNC_TCP_RUNNING_CORE
 #define CONFIG_ASYNC_TCP_RUNNING_CORE -1 //any available core
 #define CONFIG_ASYNC_TCP_USE_WDT 1 //if enabled, adds between 33us and 200us per event
-#endif
-#ifndef CONFIG_ASYNC_TCP_STACK
-#define CONFIG_ASYNC_TCP_STACK 8192 * 2
-#endif
-#ifndef CONFIG_ASYNC_TCP_QUEUE_SIZE
-#define CONFIG_ASYNC_TCP_QUEUE_SIZE 32
 #endif
 
 class AsyncClient;


### PR DESCRIPTION
Fixbug memory leaks
- AysncClient recv callback handle missing call pbuf_free()

Fix crash tcp/ip api calls
- Due to tcp_api_call_t msg declared local variant and used to as a pointer argument for the callback function. So this does not make sure that the memory holding the parameters of the pointer variant is handled right.