### PR TITLE
xQueueHandle -> QueueHandle_t

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -76,7 +76,7 @@ typedef struct {
         };
 } lwip_event_packet_t;
 
-static xQueueHandle _async_queue;
+static QueueHandle_t _async_queue;
 static TaskHandle_t _async_service_task_handle = NULL;
 
 


### PR DESCRIPTION
When building with CONFIG_FREERTOS_ENABLE_BACKWARD_COMPATIBILITY disabled, which is idf default, you need to use the newer declaration