### PR TITLE
fix(AsyncTCP.cpp): connect() returns false if tcp_connect() fails

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -700,8 +700,8 @@ bool AsyncClient::connect(IPAddress ip, uint16_t port){
     tcp_sent(pcb, &_tcp_sent);
     tcp_poll(pcb, &_tcp_poll, 1);
     //_tcp_connect(pcb, &addr, port,(tcp_connected_fn)&_s_connected);
-    _tcp_connect(pcb, _closed_slot, &addr, port,(tcp_connected_fn)&_tcp_connected);
-    return true;
+    esp_err_t err = _tcp_connect(pcb, _closed_slot, &addr, port,(tcp_connected_fn)&_tcp_connected);
+    return err == ESP_OK;
 }
 
 bool AsyncClient::connect(const char* host, uint16_t port){


### PR DESCRIPTION
Using customized eModbus library don't connect due AsyncTCP::connect() allways return true