### PR TITLE
Don't allow invalid window size when window scale is disabled

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -417,7 +417,8 @@ static esp_err_t _tcp_write(tcp_pcb * pcb, int8_t closed_slot, const char* data,
 static err_t _tcp_recved_api(struct tcpip_api_call_data *api_call_msg){
     tcp_api_call_t * msg = (tcp_api_call_t *)api_call_msg;
     msg->err = ERR_CONN;
-    if(msg->closed_slot == -1 || !_closed_slots[msg->closed_slot]) {
+    u32_t new_rcv_ann_wnd = msg->pcb->rcv_ann_right_edge - msg->pcb->rcv_nxt;
+    if((msg->closed_slot == -1 || !_closed_slots[msg->closed_slot]) && (new_rcv_ann_wnd <= 0xffff || LWIP_WND_SCALE)) {
         msg->err = 0;
         tcp_recved(msg->pcb, msg->received);
     }


### PR DESCRIPTION
Recently I noticed the ESP crashing and tried to investigate the issue to the best of my abilities. This was happening multiple times per 10 minutes, and the ESP restarting every single time. I was shown this backtrace:

```
Backtrace: 0x400837b5:0x3ffcd960 0x4008d07d:0x3ffcd980 0x40092649:0x3ffcd9a0 0x400f9a4e:0x3ffcdad0 0x400f9afc:0x3ffcdaf0 0x400d572a:0x3ffcdb10 0x400f68c8:0x3ffcdb30

  #0  0x400837b5:0x3ffcd960 in panic_abort at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/esp_system/panic.c:408
  #1  0x4008d07d:0x3ffcd980 in esp_system_abort at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/esp_system/esp_system.c:137
  #2  0x40092649:0x3ffcd9a0 in __assert_func at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/newlib/assert.c:85
  #3  0x400f9a4e:0x3ffcdad0 in tcp_update_rcv_ann_wnd at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/lwip/lwip/src/core/tcp.c:951
      (inlined by) tcp_update_rcv_ann_wnd at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/lwip/lwip/src/core/tcp.c:931
  #4  0x400f9afc:0x3ffcdaf0 in tcp_recved at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/lwip/lwip/src/core/tcp.c:991
  #5  0x400d572a:0x3ffcdb10 in _tcp_recved_api(tcpip_api_call_data*) at .pio/libdeps/esp32dev/AsyncTCP/src/AsyncTCP.cpp:419
  #6  0x400f68c8:0x3ffcdb30 in tcpip_thread_handle_msg at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/lwip/lwip/src/api/tcpip.c:172
      (inlined by) tcpip_thread at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/lwip/lwip/src/api/tcpip.c:154
```

I was able to track down the exact assert that was being triggered. 

[This](https://github.com/espressif/esp-lwip/blob/a45be9e438f6cf9c54ec150581819c3b95d5af6b/src/core/tcp.c#L951) was the assert being triggered and [this](https://github.com/espressif/esp-lwip/blob/2.1.2-esp/src/include/lwip/opt.h#L1499) was the configured option for `LWIP_WND_SCALE`. 

Since I didn't know more about the error as I wasn't able to track down how exactly this was caused, I decided to add a check in the function AsyncTCP was handling. You can check the commit for the changes.

This is most likely just a temporary fix until somebody investigates this matter to identify the root issue, but for now it should do. Please point out any issues!