### PR TITLE
Bugfix: Make library work with ESP32 v3.1.0

### DIFF
--- a/src/AsyncTCP.cpp
+++ b/src/AsyncTCP.cpp
@@ -35,6 +35,22 @@ extern "C"{
  * TCP/IP Event Task
  * */
 
+// https://github.com/espressif/arduino-esp32/issues/10526
+#ifdef CONFIG_LWIP_TCPIP_CORE_LOCKING
+#define TCP_MUTEX_LOCK()                                \
+  if (!sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) { \
+    LOCK_TCPIP_CORE();                                  \
+  }
+
+#define TCP_MUTEX_UNLOCK()                             \
+  if (sys_thread_tcpip(LWIP_CORE_LOCK_QUERY_HOLDER)) { \
+    UNLOCK_TCPIP_CORE();                               \
+  }
+#else  // CONFIG_LWIP_TCPIP_CORE_LOCKING
+#define TCP_MUTEX_LOCK()
+#define TCP_MUTEX_UNLOCK()
+#endif  // CONFIG_LWIP_TCPIP_CORE_LOCKING
+
 typedef enum {
     LWIP_TCP_SENT, LWIP_TCP_RECV, LWIP_TCP_FIN, LWIP_TCP_ERROR, LWIP_TCP_POLL, LWIP_TCP_CLEAR, LWIP_TCP_ACCEPT, LWIP_TCP_CONNECTED, LWIP_TCP_DNS
 } lwip_event_t;
@@ -688,8 +704,10 @@ bool AsyncClient::connect(IPAddress ip, uint16_t port){
     addr.type = IPADDR_TYPE_V4;
     addr.u_addr.ip4.addr = ip;
 
+    TCP_MUTEX_LOCK();
     tcp_pcb* pcb = tcp_new_ip_type(IPADDR_TYPE_V4);
     if (!pcb){
+        TCP_MUTEX_UNLOCK();
         log_e("pcb == NULL");
         return false;
     }
@@ -699,6 +717,7 @@ bool AsyncClient::connect(IPAddress ip, uint16_t port){
     tcp_recv(pcb, &_tcp_recv);
     tcp_sent(pcb, &_tcp_sent);
     tcp_poll(pcb, &_tcp_poll, 1);
+    TCP_MUTEX_UNLOCK();
     //_tcp_connect(pcb, &addr, port,(tcp_connected_fn)&_s_connected);
     esp_err_t err = _tcp_connect(pcb, _closed_slot, &addr, port,(tcp_connected_fn)&_tcp_connected);
     return err == ESP_OK;
@@ -711,8 +730,9 @@ bool AsyncClient::connect(const char* host, uint16_t port){
       log_e("failed to start task");
       return false;
     }
-    
+    TCP_MUTEX_LOCK();
     err_t err = dns_gethostbyname(host, &addr, (dns_found_callback)&_tcp_dns_found, this);
+    TCP_MUTEX_UNLOCK();
     if(err == ERR_OK) {
         return connect(IPAddress(addr.u_addr.ip4.addr), port);
     } else if(err == ERR_INPROGRESS) {
@@ -800,11 +820,13 @@ int8_t AsyncClient::_close(){
     int8_t err = ERR_OK;
     if(_pcb) {
         //log_i("");
+        TCP_MUTEX_LOCK();
         tcp_arg(_pcb, NULL);
         tcp_sent(_pcb, NULL);
         tcp_recv(_pcb, NULL);
         tcp_err(_pcb, NULL);
         tcp_poll(_pcb, NULL, 0);
+        TCP_MUTEX_UNLOCK();
         _tcp_clear_events(this);
         err = _tcp_close(_pcb, _closed_slot);
         if(err != ERR_OK) {
@@ -1271,7 +1293,9 @@ void AsyncServer::begin(){
         return;
     }
     int8_t err;
+    TCP_MUTEX_LOCK();
     _pcb = tcp_new_ip_type(IPADDR_TYPE_V4);
+    TCP_MUTEX_UNLOCK();
     if (!_pcb){
         log_e("_pcb == NULL");
         return;
@@ -1294,14 +1318,18 @@ void AsyncServer::begin(){
         log_e("listen_pcb == NULL");
         return;
     }
+    TCP_MUTEX_LOCK();
     tcp_arg(_pcb, (void*) this);
     tcp_accept(_pcb, &_s_accept);
+    TCP_MUTEX_UNLOCK();
 }
 
 void AsyncServer::end(){
     if(_pcb){
+        TCP_MUTEX_LOCK();
         tcp_arg(_pcb, NULL);
         tcp_accept(_pcb, NULL);
+        TCP_MUTEX_UNLOCK();
         if(tcp_close(_pcb) != ERR_OK){
             _tcp_abort(_pcb, -1);
         }


### PR DESCRIPTION
### What
The changes introduced in EPS32 v3.1.0 causes a runtime crash when trying to use this AsyncTCP library

`assert failed: tcp_alloc /IDF/components/lwip/lwip/src/core/tcp.c:1851 (Required to lock TCPIP core functionality!)`

### How
We fix this by applying the fix in https://github.com/espressif/arduino-esp32/issues/10526 , suggested by mathieucarbou